### PR TITLE
Read-Only String Pointer Type

### DIFF
--- a/examples/subject.rs
+++ b/examples/subject.rs
@@ -8,6 +8,8 @@ struct Foo {
     p1: Box<[u32; 10]>,
     p2: Box<[f32; 10]>,
     p3: LinkedList<u32>,
+    str_ptr: *const u8,
+    str_ptr_null_terminated: *const u8,
 }
 
 fn main() {
@@ -32,6 +34,8 @@ fn main() {
                 .unwrap(),
         ),
         p3: LinkedList::from_iter([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        str_ptr: "Test String\n\n\n\n\n\t\t\t".as_ptr(),
+        str_ptr_null_terminated: "Null-Terminated String\n\0".as_ptr(),
     };
     println!("Address: {:p}", &foo);
 

--- a/src/field/kind.rs
+++ b/src/field/kind.rs
@@ -1,4 +1,4 @@
-use super::{BoolField, Field, FloatField, HexField, IntField, PointerField};
+use super::{BoolField, Field, FloatField, HexField, IntField, PointerField, StringPointerField};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -9,6 +9,7 @@ pub enum FieldKind {
     U8, U16, U32, U64,
     F32, F64,
     Ptr,
+    StrPtr,
     Bool,
 }
 
@@ -41,7 +42,7 @@ impl FieldKind {
             Self::Unk16 | Self::I16 | Self::U16 => 2,
             Self::Unk32 | Self::I32 | Self::U32 | Self::F32 => 4,
             // TODO(ItsEthra): Pointer size is... sigh, different for 32-bit processes
-            Self::Unk64 | Self::I64 | Self::U64 | Self::F64 | Self::Ptr => 8,
+            Self::Unk64 | Self::I64 | Self::U64 | Self::F64 | Self::Ptr | Self::StrPtr => 8,
         }
     }
 
@@ -79,6 +80,9 @@ impl FieldKind {
             )),
             Self::Bool => Box::new(BoolField::new(name.unwrap_or_else(|| "boolean".into()))),
             Self::Ptr => Box::new(PointerField::new(name.unwrap_or_else(|| "pointer".into()))),
+            Self::StrPtr => Box::new(StringPointerField::new(
+                name.unwrap_or_else(|| "str_ptr".into()),
+            )),
         }
     }
 }

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -10,6 +10,8 @@ mod float;
 pub use float::*;
 mod pointer;
 pub use pointer::*;
+mod string_pointer;
+pub use string_pointer::*;
 mod boolean;
 pub use boolean::*;
 

--- a/src/field/string_pointer.rs
+++ b/src/field/string_pointer.rs
@@ -54,12 +54,6 @@ impl Field for StringPointerField {
 
         let mut str_buf = [0; 64];
         ctx.process.read(address, &mut str_buf);
-        // Sanitize string to prevent control characters like \n, \t, etc. from being displayed
-        str_buf.iter_mut().for_each(|c| {
-            if *c != b'\0' && *c < b' ' {
-                *c = b'_'
-            }
-        });
 
         ui.horizontal(|ui| {
             let mut job = LayoutJob::default();
@@ -83,9 +77,9 @@ impl Field for StringPointerField {
                         let str = std::str::from_utf8(&str_buf[..str_end])
                             .unwrap_or_else(|_| "non utf-8 sequence");
                         if v {
-                            format!("{str}")
+                            format!("{str:?}")
                         } else {
-                            format!("-> \"{str}\"")
+                            format!("-> {str:?}")
                         }
                     },
                     |_| false,

--- a/src/field/string_pointer.rs
+++ b/src/field/string_pointer.rs
@@ -1,0 +1,109 @@
+use eframe::{
+    egui::{Label, RichText, Sense},
+    epaint::{text::LayoutJob, Color32},
+};
+
+use crate::FID_M;
+
+use super::{
+    display_field_name, display_field_prelude, display_field_value, next_id, Field, FieldId,
+    FieldKind, NamedState,
+};
+
+pub struct StringPointerField {
+    id: FieldId,
+    state: NamedState,
+}
+
+impl StringPointerField {
+    pub fn new(name: String) -> Self {
+        Self {
+            id: next_id(),
+            state: NamedState::new(name),
+        }
+    }
+}
+
+impl Field for StringPointerField {
+    fn id(&self) -> FieldId {
+        self.id
+    }
+
+    fn name(&self) -> Option<String> {
+        Some(self.state.name.borrow().clone())
+    }
+
+    fn size(&self) -> usize {
+        // TODO: The size of the pointer would be 4 bytes on x86
+        8
+    }
+
+    fn kind(&self) -> super::FieldKind {
+        FieldKind::StrPtr
+    }
+
+    fn draw(
+        &self,
+        ui: &mut eframe::egui::Ui,
+        ctx: &mut crate::context::InspectionContext,
+    ) -> Option<super::FieldResponse> {
+        // TODO: The size of the pointer would be 4 bytes on x86
+        let mut buf = [0; 8];
+        ctx.process.read(ctx.address + ctx.offset, &mut buf);
+        let address = usize::from_ne_bytes(buf);
+
+        let mut str_buf = [0; 64];
+        ctx.process.read(address, &mut str_buf);
+        // Sanitize string to prevent control characters like \n, \t, etc. from being displayed
+        str_buf.iter_mut().for_each(|c| {
+            if *c != b'\0' && *c < b' ' {
+                *c = b'_'
+            }
+        });
+
+        ui.horizontal(|ui| {
+            let mut job = LayoutJob::default();
+            display_field_prelude(ui.ctx(), self, ctx, &mut job);
+            if ui.add(Label::new(job).sense(Sense::click())).clicked() {
+                ctx.select(self.id);
+            }
+            display_field_name(self, ui, ctx, &self.state, Color32::LIGHT_RED);
+            if ctx.process.can_read(address) {
+                display_field_value(
+                    self,
+                    ui,
+                    ctx,
+                    &self.state,
+                    Color32::LIGHT_BLUE,
+                    |v| {
+                        let str_end = str_buf
+                            .iter()
+                            .position(|c| *c == b'\0')
+                            .unwrap_or(str_buf.len());
+                        let str = std::str::from_utf8(&str_buf[..str_end])
+                            .unwrap_or_else(|_| "non utf-8 sequence");
+                        if v {
+                            format!("{str}")
+                        } else {
+                            format!("-> \"{str}\"")
+                        }
+                    },
+                    |_| false,
+                )
+            } else {
+                ui.add_space(2.);
+                ui.heading(
+                    RichText::new("Invalid Address")
+                        .color(Color32::RED)
+                        .font(FID_M),
+                );
+            }
+        });
+        ctx.offset += self.size();
+        None
+    }
+
+    fn codegen(&self, generator: &mut dyn crate::generator::Generator, _: &super::CodegenData) {
+        generator.add_field(self.state.name.borrow().as_str(), FieldKind::StrPtr, None);
+    }
+}

--- a/src/field/string_pointer.rs
+++ b/src/field/string_pointer.rs
@@ -74,8 +74,8 @@ impl Field for StringPointerField {
                             .iter()
                             .position(|c| *c == b'\0')
                             .unwrap_or(str_buf.len());
-                        let str = std::str::from_utf8(&str_buf[..str_end])
-                            .unwrap_or_else(|_| "non utf-8 sequence");
+                        let str = std::string::String::from_utf8_lossy(&str_buf[..str_end]);
+
                         if v {
                             format!("{str:?}")
                         } else {

--- a/src/generator/cpp.rs
+++ b/src/generator/cpp.rs
@@ -74,6 +74,7 @@ fn kind_to_type(kind: FieldKind, metadata: Option<&str>) -> Cow<'static, str> {
         FieldKind::F32 => "float".into(),
         FieldKind::F64 => "double".into(),
         FieldKind::Ptr => format!("{}*", metadata.unwrap()).into(),
+        FieldKind::StrPtr => "const char*".into(),
         FieldKind::Bool => "bool".into(),
     }
 }

--- a/src/generator/rust.rs
+++ b/src/generator/rust.rs
@@ -71,6 +71,7 @@ fn kind_to_type(kind: FieldKind, metadata: Option<&str>) -> Cow<'static, str> {
         FieldKind::F32 => "f32".into(),
         FieldKind::F64 => "f64".into(),
         FieldKind::Ptr => format!("Option<&'static {}>", metadata.unwrap()).into(),
+        FieldKind::StrPtr => "*const u8".into(),
         FieldKind::Bool => "bool".into(),
     }
 }

--- a/src/gui/tool_bar.rs
+++ b/src/gui/tool_bar.rs
@@ -300,7 +300,7 @@ impl ToolBarPanel {
         ui.separator();
         ui.add_space(2.);
 
-        create_change_field_type_group!(ui, response, BLACK, BROWN, Ptr);
+        create_change_field_type_group!(ui, response, BLACK, BROWN, Ptr, StrPtr);
     }
 }
 


### PR DESCRIPTION
## Summary
Implements a StrPtr type that displays the destination address as a utf-8 sequence.

Currently the string pointer is limited to 64 characters to prevent overflow, hence why it is read-only.